### PR TITLE
Fix Markdown syntax errors to show all labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![Apache-2.0 License](https://img.shields.io/github/license/saltstack/salt)](https://www.apache.org/licenses/LICENSE-2.0)
-[!(PyPI package)(https://badge.fury.io/py/mlx.treemap.svg)](https://pypi.org/project/mlx.treemap/)
-[!(Build status)(https://github.com/melexis/treemap/actions/workflows/python-package.yml/badge.svg?branch=main)](https://github.com/melexis/treemap/actions/workflows/python-package.yml)
+[![PyPI package](https://badge.fury.io/py/mlx.treemap.svg)](https://pypi.org/project/mlx.treemap/)
+[![Build status](https://github.com/melexis/treemap/actions/workflows/python-package.yml/badge.svg?branch=main)](https://github.com/melexis/treemap/actions/workflows/python-package.yml)
 [![Documentation](https://img.shields.io/badge/Documentation-published-brightgreen.svg)](https://melexis.github.io/treemap/)
-[!(Contributions welcome)(https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/melexis/treemap/issues)
+[![Contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/melexis/treemap/issues)
 
 # Sphinx Plugin for Treemap Generation
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     use_scm_version={
         'write_to': 'mlx/__treemap_version__.py'
     },
-    setup_requires=['setuptools_scm'],
+    setup_requires=['setuptools-scm>=6.0.0,<7.*'],
     url='https://github.com/melexis/treemap',
     license='Apache License, Version 2.0',
     author='Jasper Craeghs',


### PR DESCRIPTION
All labels show up now. See https://github.com/melexis/treemap/tree/fix-labels.