### PR TITLE
Mark this Sphinx extension as parallel safe

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    ?= -j auto
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/mlx/treemap/treemap.py
+++ b/mlx/treemap/treemap.py
@@ -32,4 +32,8 @@ def setup(app):
     app.add_directive('treemap', TreemapDirective)
     app.connect('doctree-resolved', process_item_nodes)
 
-    return {'version': version}
+    return {
+        'version': version,
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }


### PR DESCRIPTION
Enabling support for [`sphinx-build --jobs auto`](https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-j)